### PR TITLE
added some maven-eclipse-plugin configuration to the pom.xml file

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -47,6 +47,16 @@
 					</includes>
 				</configuration>
 			</plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-eclipse-plugin</artifactId>
+        <version>2.8</version>
+        <configuration>
+          <downloadSources>true</downloadSources>
+          <downloadJavadocs>true</downloadJavadocs>
+          <useProjectReferences>false</useProjectReferences>
+        </configuration>
+      </plugin>
 		</plugins>
 	</build>
 	<repositories>


### PR DESCRIPTION
So that the Maven Eclipse plugin downloads javadoc and source jars, and link them into the Eclipse project generated with "mvn eclipse:eclipse"
