### PR TITLE
Mutation testing with pitest.org

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -57,6 +57,22 @@
           <useProjectReferences>false</useProjectReferences>
         </configuration>
       </plugin>
+      <plugin>
+        <!--
+          Run mutation tests like this:
+          mvn clean install org.pitest:pitest-maven:mutationCoverage
+          reports can be found in target/pit-reports
+        -->
+        <groupId>org.pitest</groupId>
+        <artifactId>pitest-maven</artifactId>
+        <version>0.24</version>
+        <configuration>
+          <inScopeClasses>
+            <param>com.jayway.changeless*</param>
+          </inScopeClasses>
+          <threads>4</threads>
+        </configuration>
+      </plugin>
 		</plugins>
 	</build>
 	<repositories>


### PR DESCRIPTION
Run the tests with maven like this:
mvn clean install org.pitest:pitest-maven:mutationCoverage
and find the reports in target/pit-reports.
There are many false positives but there are also some interesting candidates for tests
to be written.
