### PR TITLE
Merge methods

### DIFF
--- a/src/main/java/com/jayway/changeless/maps/ImmutableHashMap.java
+++ b/src/main/java/com/jayway/changeless/maps/ImmutableHashMap.java
@@ -160,4 +160,16 @@ final class ImmutableHashMap<K, V> implements Map<K, V> {
 	public boolean matches(K input) {
 		return contains(input);
 	}
+
+	@Override
+	public Map<K, V> merge(Map<K, V> updates) {
+		if (updates == null) {
+			throw new IllegalArgumentException("updates cannot be null");
+		}
+		Map<K, V> updated = this;
+		for (Tuple<K, V> entry : updates) {
+			updated = updated.put(entry.getFirst(), entry.getSecond());
+		}
+		return updated;
+	}
 }

--- a/src/main/java/com/jayway/changeless/maps/Map.java
+++ b/src/main/java/com/jayway/changeless/maps/Map.java
@@ -84,4 +84,17 @@ public interface Map<K,V> extends Sequenceable<Tuple<K,V>>, Fn<K, Optional<V>>, 
 	 * @return true if maps contains the given key; false otherwise.
 	 */
 	boolean contains(K key);
+
+	/**
+	 * Create a new map, based on this one, but with additional entries from
+	 * the given map, overwriting any counterparts in this map.
+	 * <p>
+	 * In other words, the following is true:
+	 * <pre><code>Maps.of(1,"1", 2,"2")
+	 *    .merge(Maps.of(2,"TWO", 3,"3"))
+	 *    .equals(Maps.of(1,"1", 2,"TWO", 3,"3"));</code></pre>
+	 * @param updates
+	 * @return
+	 */
+	Map<K,V> merge(Map<K, V> updates);
 }

--- a/src/main/java/com/jayway/changeless/maps/Map.java
+++ b/src/main/java/com/jayway/changeless/maps/Map.java
@@ -93,8 +93,9 @@ public interface Map<K,V> extends Sequenceable<Tuple<K,V>>, Fn<K, Optional<V>>, 
 	 * <pre><code>Maps.of(1,"1", 2,"2")
 	 *    .merge(Maps.of(2,"TWO", 3,"3"))
 	 *    .equals(Maps.of(1,"1", 2,"TWO", 3,"3"));</code></pre>
-	 * @param updates
-	 * @return
+	 * @param updates The updates that should overwrite the entries of this map
+	 * in the new map.
+	 * @return A new map that is updates merged unto this map.
 	 */
 	Map<K,V> merge(Map<K, V> updates);
 }

--- a/src/main/java/com/jayway/changeless/records/DefaultRecordBuilder.java
+++ b/src/main/java/com/jayway/changeless/records/DefaultRecordBuilder.java
@@ -1,16 +1,18 @@
 package com.jayway.changeless.records;
 
 import java.lang.reflect.Proxy;
+import java.util.HashMap;
 
-class DefaultRecordBuilder<T extends Record> implements RecordBuilder<T> {
-	private final Class<T> clazz;
+class DefaultRecordBuilder<T extends Record<?>> implements RecordBuilder<T> {
+	private final Class<? extends T> clazz;
+	private final HashMap<String, Class<?>> types;
 	private ClassLoader classLoader;
 	private Class<?>[] interfaces;
 	private RecordValidator validator = new DefaultRecordValidator();
 
-	private DefaultRecordBuilder(Class<T> clazz) {
+	private DefaultRecordBuilder(Class<? extends T> clazz) {
 		this.clazz = clazz;
-		validator.validateRecord(clazz);
+		types = validator.validateRecord(clazz);
 		classLoader = clazz.getClassLoader();
 		interfaces = new Class[] { clazz };
 	}
@@ -18,10 +20,10 @@ class DefaultRecordBuilder<T extends Record> implements RecordBuilder<T> {
 	@SuppressWarnings("unchecked")
 	public T create() {
 		return (T) Proxy.newProxyInstance(classLoader, interfaces,
-				new RecordInceptor<T>(clazz));
+				new RecordInceptor(clazz, types));
 	}
 	
-	public static <T extends Record> RecordBuilder<T> create(Class<T> clazz) {
+	public static <T extends Record<?>> RecordBuilder<T> create(Class<T> clazz) {
 		return new DefaultRecordBuilder<T>(clazz);
 	}
 }

--- a/src/main/java/com/jayway/changeless/records/DefaultRecordBuilder.java
+++ b/src/main/java/com/jayway/changeless/records/DefaultRecordBuilder.java
@@ -13,14 +13,17 @@ class DefaultRecordBuilder<T extends Record<?>> implements RecordBuilder<T> {
 	private DefaultRecordBuilder(Class<? extends T> clazz) {
 		this.clazz = clazz;
 		types = validator.validateRecord(clazz);
-		classLoader = clazz.getClassLoader();
+		classLoader = Thread.currentThread().getContextClassLoader();
+		if (classLoader == null) {
+			classLoader = clazz.getClassLoader();
+		}
 		interfaces = new Class[] { clazz };
 	}
 
 	@SuppressWarnings("unchecked")
 	public T create() {
 		return (T) Proxy.newProxyInstance(classLoader, interfaces,
-				new RecordInceptor(clazz, types));
+				new RecordInceptor(clazz, types, classLoader));
 	}
 	
 	public static <T extends Record<?>> RecordBuilder<T> create(Class<T> clazz) {

--- a/src/main/java/com/jayway/changeless/records/Record.java
+++ b/src/main/java/com/jayway/changeless/records/Record.java
@@ -35,6 +35,9 @@ public interface Record<T extends Record<T>> {
 	 * Entries in the given updates map, where the key do not match any field
 	 * in the record, will be merged over as well. This can be used to attach
 	 * meta-data, or other types of hidden information, to the record.
+	 * <p>
+	 * This method differs from {@link Map#merge(Map)} in that it catches type
+	 * errors with respect to the defined record interface and its fields.
 	 * @param updates The map of field names to values.
 	 * @return A new record of the same type, with the mapped fields updated
 	 * to new values.

--- a/src/main/java/com/jayway/changeless/records/Record.java
+++ b/src/main/java/com/jayway/changeless/records/Record.java
@@ -3,7 +3,7 @@ package com.jayway.changeless.records;
 import com.jayway.changeless.maps.Map;
 
 /**
- * A record is an immutable collection of unordered labeled fields defined by a
+ * A record is an immutable collection of unordered labelled fields defined by a
  * record interface. Each field has an extractor method and a mutator method.
  * The extractor method can be used to extract the value of the field in the
  * record and the mutator is used to create a copy of the record where the field
@@ -20,11 +20,27 @@ import com.jayway.changeless.maps.Map;
  * </code>
  * </p>
  */
-public interface Record {
+public interface Record<T extends Record<T>> {
 	/**
 	 * Returns the data of this record as a map from the field name to the values 
 	 * of the fields.  
 	 * @return the data of this record as a map.
 	 */
 	Map<String, Object> getData();
+
+	/**
+	 * Merge the entries of the given map, into the backing map of this record,
+	 * returning a new record with the updated entries.
+	 * <p>
+	 * Entries in the given updates map, where the key do not match any field
+	 * in the record, will be merged over as well. This can be used to attach
+	 * meta-data, or other types of hidden information, to the record.
+	 * @param updates The map of field names to values.
+	 * @return A new record of the same type, with the mapped fields updated
+	 * to new values.
+	 * @throws RecordValidationException if the updated entries contain values
+	 * of types that do not match those specified by the fields of this record
+	 * interface.
+	 */
+	T merge(Map<String, ?> updates);
 }

--- a/src/main/java/com/jayway/changeless/records/RecordBuilder.java
+++ b/src/main/java/com/jayway/changeless/records/RecordBuilder.java
@@ -4,7 +4,7 @@ package com.jayway.changeless.records;
  * A builder capable of building record instances of a given record type.
  * @param <T> the type of the records that this builder can create.
  */
-public interface RecordBuilder<T extends Record> {
+public interface RecordBuilder<T extends Record<?>> {
 	/**
 	 * Creates a new {@link Record} instance of type T. 
 	 * @return a new {@link Record} instance of type T.

--- a/src/main/java/com/jayway/changeless/records/RecordInterceptor.java
+++ b/src/main/java/com/jayway/changeless/records/RecordInterceptor.java
@@ -110,10 +110,14 @@ class RecordInceptor implements InvocationHandler {
 	}
 	
 	public Object merge(Object arg) {
+		if (!(arg instanceof Map)) {
+			throw new IllegalArgumentException(
+					arg + " is not a changeless Map");
+		}
 		@SuppressWarnings("unchecked")
-		Map<String, Object> merging = (Map<String, Object>) arg;
+		Map<String, Object> updates = (Map<String, Object>) arg;
 		Map<String, Object> newData = data;
-		for (Tuple<String, Object> entry : merging) {
+		for (Tuple<String, Object> entry : updates) {
 			String field = entry.getFirst();
 			Object value = entry.getSecond();
 			Class<?> type = types.get(field);

--- a/src/main/java/com/jayway/changeless/records/RecordInterceptor.java
+++ b/src/main/java/com/jayway/changeless/records/RecordInterceptor.java
@@ -15,19 +15,22 @@ class RecordInceptor implements InvocationHandler {
 	private final Map<String, Object> data;
 	private final HashMap<String, Class<?>> types;
 	private final Class<?> clazz;
+	private final ClassLoader classLoader;
 	
-	public RecordInceptor(Class<?> clazz, HashMap<String, Class<?>> types) {
-		this(clazz, Maps.<String,Object>empty(), types);
+	public RecordInceptor(Class<?> clazz, HashMap<String, Class<?>> types, ClassLoader classLoader) {
+		this(clazz, Maps.<String,Object>empty(), types, classLoader);
 	}
 	
 	private RecordInceptor(
 			Class<?> clazz,
 			Map<String, Object> data,
-			HashMap<String, Class<?>> types) {
+			HashMap<String, Class<?>> types,
+			ClassLoader classLoader) {
 		Guard.notNull(clazz, "clazz");
 		this.clazz = clazz;
 		this.data = data;
 		this.types = types;
+		this.classLoader = classLoader;
 	}
 	
 	@Override
@@ -69,9 +72,9 @@ class RecordInceptor implements InvocationHandler {
 			}
 			
 			Map<String, Object> newData = data.put(methodName, value);
-			return Proxy.newProxyInstance(clazz.getClassLoader(),
+			return Proxy.newProxyInstance(classLoader,
 					new Class[] { clazz }, 
-					new RecordInceptor(clazz, newData, types));
+					new RecordInceptor(clazz, newData, types, classLoader));
 		} 
 		
 		Optional<Object> result = data.get(methodName);
@@ -123,9 +126,9 @@ class RecordInceptor implements InvocationHandler {
 			newData = newData.put(field, value);
 		}
 		
-		return Proxy.newProxyInstance(clazz.getClassLoader(),
+		return Proxy.newProxyInstance(classLoader,
 				new Class[] { clazz }, 
-				new RecordInceptor(clazz, newData, types));
+				new RecordInceptor(clazz, newData, types, classLoader));
 	}
 
 	@Override

--- a/src/main/java/com/jayway/changeless/records/RecordValidator.java
+++ b/src/main/java/com/jayway/changeless/records/RecordValidator.java
@@ -1,5 +1,7 @@
 package com.jayway.changeless.records;
 
+import java.util.HashMap;
+
 /**
  * A validator capable of validating record classes. 
  */
@@ -7,7 +9,8 @@ interface RecordValidator {
 	/**
 	 * Validates the given record class. 
 	 * @param clazz the class to validate.
+	 * @return A map of properties to their data type.
 	 * @throws RecordValidationException if the given record class is not valid.
 	 */
-	void validateRecord(Class<? extends Record> clazz);
+	HashMap<String, Class<?>> validateRecord(Class<?> clazz);
 }

--- a/src/main/java/com/jayway/changeless/records/Records.java
+++ b/src/main/java/com/jayway/changeless/records/Records.java
@@ -9,7 +9,7 @@ package com.jayway.changeless.records;
  * Below is an example of what is possible.
  * <code>
  * <pre>
- * interface Planet extends Record {
+ * interface Planet extends Record&lt;Planet&gt; {
  *   String name();
  *   Planet name(String name);
  *   double mass();
@@ -54,7 +54,7 @@ public final class Records {
 	 * @throws RecordValidationException if the given class is not a valid {@link Record} interface. 
 	 * see {@link Record} for more information.
 	 */
-	public static <T extends Record> T of(Class<T> clazz) {
+	public static <T extends Record<?>> T of(Class<T> clazz) {
 		return builder(clazz).create();
 	}
 	
@@ -64,7 +64,7 @@ public final class Records {
 	 * @param clazz the class of the record to create.
 	 * @return a new {@link RecordBuilder} capable of creating record instances of type T. 
 	 */
-	public static <T extends Record> RecordBuilder<T> builder(Class<T> clazz) {
+	public static <T extends Record<?>> RecordBuilder<T> builder(Class<T> clazz) {
 		return DefaultRecordBuilder.create(clazz);
 	}
 }

--- a/src/test/java/com/jayway/changeless/maps/MapsTests.java
+++ b/src/test/java/com/jayway/changeless/maps/MapsTests.java
@@ -168,4 +168,27 @@ public class MapsTests {
 		Map<Integer, String> map = Maps.of(2, "TWO");
 		assertEquals("Expected default value", map.get(1, "ONE"), "ONE");
 	}
+	
+	@Test
+	public void mergeUpdatesMultipleValues() {
+		Map<Integer,String> orig = Maps.of(1, "1", 2, "2", 3, "3");
+		Map<Integer,String> updates = Maps.of(2, "TWO", 3, "THREE", 4, "FOUR");
+		Map<Integer,String> expectedResult =
+				Maps.of(1, "1", 2, "TWO", 3, "THREE", 4, "FOUR");
+		assertEquals("Expected merged map",
+				expectedResult, orig.merge(updates));
+	}
+	
+	@Test(expected = IllegalArgumentException.class)
+	public void updatesMapToMergeCannotBeNull() {
+		Maps.empty().merge(null);
+	}
+	
+	@Test
+	public void mergeExampleTest() {
+		assertTrue("The example in the merge javadoc is wrong",
+				Maps.of(1,"1", 2,"2")
+					.merge(Maps.of(2,"TWO", 3,"3"))
+					.equals(Maps.of(1,"1", 2,"TWO", 3,"3")));
+	}
 }

--- a/src/test/java/com/jayway/changeless/records/RecordValidationTests.java
+++ b/src/test/java/com/jayway/changeless/records/RecordValidationTests.java
@@ -3,12 +3,18 @@ package com.jayway.changeless.records;
 import org.junit.Test;
 
 import com.jayway.changeless.maps.Map;
+import com.jayway.changeless.maps.Maps;
 
 public class RecordValidationTests {
 
-	private class ClassRecord implements Record {
+	private class ClassRecord implements Record<ClassRecord> {
 		@Override
 		public Map<String, Object> getData() {
+			return null;
+		}
+
+		@Override
+		public ClassRecord merge(Map<String, ?> of) {
 			return null;
 		}
 	}
@@ -18,7 +24,7 @@ public class RecordValidationTests {
 		Records.of(ClassRecord.class);
 	}
 	
-	private interface MissingMutatorRecord extends Record {
+	private interface MissingMutatorRecord extends Record<MissingMutatorRecord> {
 		String foo();
 	}
 	
@@ -27,7 +33,7 @@ public class RecordValidationTests {
 		Records.of(MissingMutatorRecord.class);
 	}
 	
-	private interface MissingExtractorRecord extends Record {
+	private interface MissingExtractorRecord extends Record<MissingExtractorRecord> {
 		MissingExtractorRecord foo(String bar);
 	}
 	
@@ -36,7 +42,7 @@ public class RecordValidationTests {
 		Records.of(MissingExtractorRecord.class);
 	}
 	
-	private interface DuplicateMutatorRecord extends Record {
+	private interface DuplicateMutatorRecord extends Record<DuplicateMutatorRecord> {
 		String foo();
 		DuplicateMutatorRecord foo(String bar);
 		DuplicateMutatorRecord foo(String bar, String baz);
@@ -47,7 +53,7 @@ public class RecordValidationTests {
 		Records.of(DuplicateMutatorRecord.class);
 	}
 	
-	private interface InvalidExtratorRecord extends Record {
+	private interface InvalidExtratorRecord extends Record<InvalidExtratorRecord> {
 		void foo();
 		InvalidExtratorRecord foo(String bar);
 	}
@@ -57,7 +63,7 @@ public class RecordValidationTests {
 		Records.of(InvalidExtratorRecord.class);
 	}
 	
-	private interface InvalidMutatorReturnRecord extends Record {
+	private interface InvalidMutatorReturnRecord extends Record<InvalidMutatorReturnRecord> {
 		String foo();
 		int foo(String bar);
 	}
@@ -67,7 +73,7 @@ public class RecordValidationTests {
 		Records.of(InvalidMutatorReturnRecord.class);
 	}
 	
-	private interface InvalidMutatorParameterTypeRecord extends Record {
+	private interface InvalidMutatorParameterTypeRecord extends Record<InvalidMutatorParameterTypeRecord> {
 		String foo();
 		InvalidMutatorParameterTypeRecord foo(int bar);
 	}
@@ -77,7 +83,7 @@ public class RecordValidationTests {
 		Records.of(InvalidMutatorParameterTypeRecord.class);
 	}
 	
-	private interface InvalidMutatorParameterCountRecord extends Record {
+	private interface InvalidMutatorParameterCountRecord extends Record<InvalidMutatorParameterCountRecord> {
 		String foo();
 		InvalidMutatorParameterCountRecord foo(String foo, int bar);
 	}
@@ -93,6 +99,18 @@ public class RecordValidationTests {
 	
 	@Test(expected=RecordValidationException.class)
 	public void throwOnInheritedErrors() {
-		Records.of(InheritErrorRecord.class);
+		Class<InheritErrorRecord> clazz = InheritErrorRecord.class;
+		Records.of(clazz);
+	}
+	
+	private interface Valid extends Record<Valid> {
+		String foo();
+		Valid foo(String str);
+	}
+	
+	@Test(expected=RecordValidationException.class)
+	public void throwOnMergeWithWronglyTypedValues() {
+		Valid valid = Records.of(Valid.class);
+		valid.merge(Maps.of("foo", 1));
 	}
 }

--- a/src/test/java/com/jayway/changeless/records/RecordsTests.java
+++ b/src/test/java/com/jayway/changeless/records/RecordsTests.java
@@ -1,12 +1,12 @@
 package com.jayway.changeless.records;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.*;
 
 import org.junit.Test;
 
 import com.jayway.changeless.functions.Fn2;
 import com.jayway.changeless.maps.Map;
+import com.jayway.changeless.maps.Maps;
 import com.jayway.changeless.sequences.Sequence;
 import com.jayway.changeless.sequences.Sequences;
 import com.jayway.changeless.stubs.Address;
@@ -43,11 +43,13 @@ public class RecordsTests {
 		assertFalse("not equals", p1.equals(p3));
 	}
 	
-	interface Planet extends Record {
+	interface Planet extends Record<Planet> {
 		String name();
 		Planet name(String name);
 		double mass();
 		Planet mass(double mass);
+		String category();
+		Planet category(String category);
 	}
 	
 	@Test
@@ -95,5 +97,23 @@ public class RecordsTests {
 		
 		assertEquals("Jane", data.get("name").getValue());
 		assertEquals(address, data.get("address").getValue());
+	}
+	
+	@Test
+	public void mergeChangesManyValues() {
+		Planet earth = Records.of(Planet.class)
+				.mass(1.0).name("earth").category("planet");
+		Planet mars = earth.merge(Maps.of("mass", 0.11, "name", "mars"));
+		
+		assertEquals("planet", mars.category());
+		assertEquals(0.11, mars.mass(), 0.00001);
+		assertEquals("mars", mars.name());
+	}
+	
+	@Test
+	public void mergeMustMaintainFieldlessEntries() {
+		Planet planet = Records.of(Planet.class);
+		planet = planet.merge(Maps.of("strawberry", true));
+		assertTrue((Boolean) planet.getData().get("strawberry", false));
 	}
 }

--- a/src/test/java/com/jayway/changeless/records/RecordsTests.java
+++ b/src/test/java/com/jayway/changeless/records/RecordsTests.java
@@ -116,4 +116,9 @@ public class RecordsTests {
 		planet = planet.merge(Maps.of("strawberry", true));
 		assertTrue((Boolean) planet.getData().get("strawberry", false));
 	}
+	
+	@Test(expected = IllegalArgumentException.class)
+	public void mergedMapCannotBeNull() {
+		Records.of(Planet.class).merge(null);
+	}
 }

--- a/src/test/java/com/jayway/changeless/stubs/Address.java
+++ b/src/test/java/com/jayway/changeless/stubs/Address.java
@@ -2,7 +2,7 @@ package com.jayway.changeless.stubs;
 
 import com.jayway.changeless.records.Record;
 
-public interface Address extends Record {
+public interface Address extends Record<Address> {
 	Address street(String street);
 	String street();
 	Address houseNumber(int houseNumber);

--- a/src/test/java/com/jayway/changeless/stubs/Person.java
+++ b/src/test/java/com/jayway/changeless/stubs/Person.java
@@ -2,7 +2,7 @@ package com.jayway.changeless.stubs;
 
 import com.jayway.changeless.records.Record;
 
-public interface Person extends Record {
+public interface Person extends Record<Person> {
 	String name();
 	Person name(String name);
 	Address address();


### PR DESCRIPTION
Added a merge(Map) method to Record and Map, to make it easier to change multiple entries. Also makes it (implicitly) possible to attach hidden meta-data to records, via the underlying `data` map. This is useful if the records are used in mapping layers that like to attach hidden storage related state to entities.
